### PR TITLE
🐛 오늘 미룬 할 일이 당일 즉시 활성화되는 버그 수정

### DIFF
--- a/apps/web/db/local/schema/review.ts
+++ b/apps/web/db/local/schema/review.ts
@@ -12,7 +12,8 @@ export const review = sqliteTable('review', {
     .notNull(),
   updatedAt: text('updated_at')
     .default(sql`CURRENT_TIMESTAMP`)
-    .notNull(),
+    .notNull()
+    .$onUpdateFn(() => sql`CURRENT_TIMESTAMP`),
   deletedAt: text('deleted_at'),
   isSynced: integer('is_synced').default(0),
 });

--- a/apps/web/db/local/schema/todo.ts
+++ b/apps/web/db/local/schema/todo.ts
@@ -17,7 +17,8 @@ export const todo = sqliteTable('todo', {
     .notNull(),
   updatedAt: text('updated_at')
     .default(sql`CURRENT_TIMESTAMP`)
-    .notNull(),
+    .notNull()
+    .$onUpdateFn(() => sql`CURRENT_TIMESTAMP`),
   deletedAt: text('deleted_at'),
   isSynced: integer('is_synced').default(0),
 });


### PR DESCRIPTION
## 📌 관련 이슈

- #23

## 📑 변경 사항

- [ ] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 문서 업데이트
- [x] 버그 수정
- [ ] 기타

## 💭 작업 내용

`todo` 스키마의 `updatedAt` 컬럼에 `.$onUpdateFn()`이 없어, 미루기 액션 시 `updatedAt`이 갱신되지 않는 문제가 있었습니다.

이로 인해 복구 로직(`TodoRecoveryProvider`)에서 날짜 비교 시 오래된 `updatedAt` 값을 참조하여 오늘 미룬 할 일도 만료된 것으로 판단, 당일 즉시 활성화되는 버그가 발생했습니다.

### 변경 내용

- `todo` 스키마 `updatedAt` 컬럼에 **.$onUpdateFn(() => sql`CURRENT_TIMESTAMP`)** 추가

## 📸 스크린샷