### PR TITLE
🐛 삭제한 Todo가 화면에 나타나는 버그 수정

### DIFF
--- a/apps/web/app/api/sync/todo/route.ts
+++ b/apps/web/app/api/sync/todo/route.ts
@@ -52,7 +52,7 @@ export async function POST(req: NextRequest) {
           updatedAt: sql`excluded.updated_at`,
           deletedAt: sql`excluded.deleted_at`,
         },
-        setWhere: sql`excluded.updated_at > ${todo.updatedAt}`,
+        setWhere: sql`excluded.deleted_at IS NOT NULL OR excluded.updated_at > ${todo.updatedAt}`,
       });
 
     return NextResponse.json({ success: true, count: items.length });

--- a/apps/web/components/providers/todo-list-provider.tsx
+++ b/apps/web/components/providers/todo-list-provider.tsx
@@ -94,6 +94,7 @@ export function TodoListProvider({ children }: { children: React.ReactNode }) {
   };
 
   useEffect(() => {
+    if (syncStatus !== 'success') return;
     (() => fetchTodo())();
   }, [syncStatus, fetchTodo]);
 

--- a/apps/web/db/local/schema/todo.ts
+++ b/apps/web/db/local/schema/todo.ts
@@ -20,7 +20,5 @@ export const todo = sqliteTable('todo', {
     .notNull()
     .$onUpdateFn(() => sql`(strftime('%Y-%m-%dT%H:%M:%S.000Z', 'now'))`),
   deletedAt: text('deleted_at'),
-  isSynced: integer('is_synced')
-    .default(0)
-    .$onUpdateFn(() => 0),
+  isSynced: integer('is_synced').default(0),
 });

--- a/apps/web/services/sync.ts
+++ b/apps/web/services/sync.ts
@@ -92,7 +92,7 @@ const pullTodo = async (db: DbInstance): Promise<void> => {
         deletedAt: sql`excluded.deleted_at`,
         isSynced: 1,
       },
-      setWhere: sql`excluded.updated_at > ${localTodo.updatedAt}`,
+      setWhere: sql`excluded.deleted_at IS NOT NULL OR excluded.updated_at > ${localTodo.updatedAt}`,
     });
 };
 

--- a/apps/web/services/todo.ts
+++ b/apps/web/services/todo.ts
@@ -36,6 +36,7 @@ export const todoService = {
         status,
         deferReason: null,
         deferCount: keepDeferCount ? undefined : 0,
+        isSynced: 0,
       })
       .where(eq(todo.id, id)),
   updateDeferStatus: (db: DbInstance, { id, reason }: DeferTodoParams) =>
@@ -45,11 +46,15 @@ export const todoService = {
         status: TodoStatus.DEFERRED,
         deferReason: reason,
         deferCount: sql`${todo.deferCount} + 1`,
+        isSynced: 0,
       })
       .where(eq(todo.id, id)),
   deleteTodo: (db: DbInstance, id: string) =>
     db
       .update(todo)
-      .set({ deletedAt: sql`CURRENT_TIMESTAMP`, isSynced: 0 })
+      .set({
+        deletedAt: sql`(strftime('%Y-%m-%dT%H:%M:%S.000Z', 'now'))`,
+        isSynced: 0,
+      })
       .where(eq(todo.id, id)),
 };


### PR DESCRIPTION
## 📌 관련 이슈

- #28

## 📑 변경 사항

- [ ] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 문서 업데이트
- [x] 버그 수정
- [ ] 기타

## 💭 작업 내용

- `syncStatus`가 변경될 때마다 `fetchTodo`가 실행되어, Pull 완료 전 `deletedAt: null` 상태의 데이터가 화면에 렌더링되는 문제 수정
- `syncStatus === 'success'`일 때만 `fetchTodo`가 실행되도록 조건 추가
- **근본 원인**: `JsStorageDb`의 nullable 컬럼 값 유실 버그로 인해 매 세션마다 `deletedAt`이 `null`로 초기화됨 → 추후 IndexedDB 기반 라이브러리로 교체 예정

## 📸 스크린샷