### PR TITLE
🚑️ wa-sqlite 동시 쿼리 충돌 방지를 위한 쿼리 큐 추가

### DIFF
--- a/apps/web/db/local/index.ts
+++ b/apps/web/db/local/index.ts
@@ -13,6 +13,14 @@ type Engine = { sqlite3: SQLiteAPI; db: number };
 
 let engine: Engine | null = null;
 
+let queryQueue: Promise<unknown> = Promise.resolve();
+
+const enqueue = <T>(fn: () => Promise<T>): Promise<T> => {
+  const result = queryQueue.then(fn);
+  queryQueue = result.catch(() => {});
+  return result;
+};
+
 const initEngine = async (): Promise<Engine> => {
   if (engine) return engine;
 
@@ -31,22 +39,27 @@ export const getDb = async () => {
 
   return drizzle(
     async (sql, params, method) => {
-      try {
-        const rows: unknown[] = [];
-        for await (const stmt of eng.sqlite3.statements(eng.db, sql)) {
-          if (params.length) {
-            eng.sqlite3.bind_collection(stmt, params as SQLiteCompatibleType[]);
+      return enqueue(async () => {
+        try {
+          const rows: unknown[] = [];
+          for await (const stmt of eng.sqlite3.statements(eng.db, sql)) {
+            if (params.length) {
+              eng.sqlite3.bind_collection(
+                stmt,
+                params as SQLiteCompatibleType[],
+              );
+            }
+            while ((await eng.sqlite3.step(stmt)) === SQLite.SQLITE_ROW) {
+              rows.push(eng.sqlite3.row(stmt));
+            }
           }
-          while ((await eng.sqlite3.step(stmt)) === SQLite.SQLITE_ROW) {
-            rows.push(eng.sqlite3.row(stmt));
-          }
+          return { rows: method === 'run' ? [] : rows };
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : error;
+          console.error('❌ SQLite Proxy Error:', errorMessage);
+          throw error;
         }
-        return { rows: method === 'run' ? [] : rows };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : error;
-        console.error('❌ SQLite Proxy Error:', errorMessage);
-        throw error;
-      }
+      });
     },
     { schema },
   );


### PR DESCRIPTION
## 📑 변경 사항

- [ ] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 문서 업데이트
- [x] 버그 수정
- [ ] 기타

## 💭 작업 내용

### 문제

`wa-sqlite`는 동시 쿼리를 지원하지 않아, 여러 쿼리가 동시에 실행될 경우 `bad parameter or other API misuse` 에러가 발생했습니다.

동기화(`sync`) 실행 중 다른 쿼리가 동시에 실행되는 경우 wasm 메모리 충돌이 발생하는 것이 원인이었습니다.

### 해결

쿼리 큐(`queryQueue`)를 추가해 모든 쿼리가 순차적으로 실행되도록 했습니다.

```ts
let queryQueue: Promise<unknown> = Promise.resolve();

const enqueue = <T>(fn: () => Promise<T>): Promise<T> => {
  const result = queryQueue.then(fn);
  queryQueue = result.catch(() => {});
  return result;
};
```

## 📸 스크린샷
